### PR TITLE
Add escape rooms log page

### DIFF
--- a/app/content/escape-rooms.md
+++ b/app/content/escape-rooms.md
@@ -15,7 +15,8 @@ A log of escape rooms I've done
 | 24/01/2026 | Mindworks | Soggy Bottom | Chris, Helen, Chilly | 8/10 |
 | 20/08/2025 | Bewilder Box | The Bewilder Box Initiative | Chilly | 7/10 |
 | 22/03/2025 | Mindworks | Smugglers Ruin | Chris, Helen, Chilly | 9/10 |
-| 07/09/2024 | Presuming Eds | Escape the Vault | Chris, Helen, Chilly | 4/10 |
+| 07/09/2024 | Ready Escape Rooms | Escape the Vault | Chris, Helen, Chilly | 4/10 |
 | 17/01/2024 | Bewilder Box | Judgement D.A.V.E | Chilly | 7/10 |
 | 11/12/2023 | Mindworks | Mission Berlin | Chris, Helen, Chilly | 9/10 |
 | 21/01/2023 | Mindworks | Strapped for Cash | Chris, Helen, Chilly | 10/10 |
+| 07/05/2017 | Escape Game Brighton |  | Sam, Charlotte, Chilly |  |


### PR DESCRIPTION
Adds a new `/escape-rooms/` page logging escape rooms completed, with columns for date, company, room, who with, and rating.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PdXz9Acr6Wyd9mpnc6GTL8)_