### PR TITLE
Add time-based ApexCharts graphs to escape rooms and gigs pages

### DIFF
--- a/app/content/escape-rooms.md
+++ b/app/content/escape-rooms.md
@@ -8,6 +8,12 @@ permalink: /escape-rooms/
 
 A log of escape rooms I've done
 
+<div class="chartWrap">
+	<div class="chart chartFullwidth">
+		<div id="escapeRoomsChart"></div>
+	</div>
+</div>
+
 | Date | Company | Room | Who with | Rating |
 | ---- | ------- | ---- | -------- | ------ |
 | 23/05/2026 | Pier Pressure | Pavilion Perplex | Chris, Laurz | 7/10 |
@@ -20,3 +26,45 @@ A log of escape rooms I've done
 | 11/12/2023 | Mindworks | Mission Berlin | Chris, Helen, Chilly | 9/10 |
 | 21/01/2023 | Mindworks | Strapped for Cash | Chris, Helen, Chilly | 10/10 |
 | 07/05/2017 | Escape Game Brighton |  | Sam, Charlotte, Chilly |  |
+
+<script src="https://cdn.jsdelivr.net/npm/apexcharts"></script>
+<script>
+new ApexCharts(document.querySelector('#escapeRoomsChart'), {
+	chart: {
+		height: 250,
+		type: 'area',
+		stacked: true,
+		toolbar: { show: false },
+		zoom: { enabled: false }
+	},
+	stroke: { curve: 'smooth' },
+	dataLabels: { enabled: false },
+	fill: {
+		type: 'gradient',
+		gradient: {
+			shadeIntensity: 1,
+			inverseColors: false,
+			opacityFrom: 0.45,
+			opacityTo: 0.05,
+			stops: [20, 100]
+		}
+	},
+	yaxis: {
+		tickAmount: 4,
+		labels: {
+			formatter: function(val) { return Math.round(val); }
+		}
+	},
+	series: [{
+		name: 'Escape Rooms',
+		data: [
+			{ x: 2017, y: 1 },
+			{ x: 2023, y: 2 },
+			{ x: 2024, y: 2 },
+			{ x: 2025, y: 2 },
+			{ x: 2026, y: 3 }
+		]
+	}],
+	colors: ['#35eb93']
+}).render();
+</script>

--- a/app/content/gigs-and-shows.md
+++ b/app/content/gigs-and-shows.md
@@ -8,6 +8,12 @@ permalink: /gigs-and-shows/
 
 Gigs, live music, shows and nights out I've attended
 
+<div class="chartWrap">
+	<div class="chart chartFullwidth">
+		<div id="gigsChart"></div>
+	</div>
+</div>
+
 ## Historial record
 
 | Title | Location | Date |
@@ -79,6 +85,69 @@ Gigs, live music, shows and nights out I've attended
 | Red Hot Chilli Peppers | Hyde Park, London | 19/06/2004 |
 | Stereophonics | Earls Court Exhibition Centre, London | 16/12/2003 |
 | Travis | Brighton Centre, Brighton | 14/12/2001 |
+
+<script src="https://cdn.jsdelivr.net/npm/apexcharts"></script>
+<script>
+new ApexCharts(document.querySelector('#gigsChart'), {
+	chart: {
+		height: 250,
+		type: 'area',
+		stacked: true,
+		toolbar: { show: false },
+		zoom: { enabled: false }
+	},
+	stroke: { curve: 'smooth' },
+	dataLabels: { enabled: false },
+	fill: {
+		type: 'gradient',
+		gradient: {
+			shadeIntensity: 1,
+			inverseColors: false,
+			opacityFrom: 0.45,
+			opacityTo: 0.05,
+			stops: [20, 100]
+		}
+	},
+	yaxis: {
+		tickAmount: 4,
+		labels: {
+			formatter: function(val) { return Math.round(val); }
+		}
+	},
+	series: [{
+		name: 'Gigs & Shows',
+		data: [
+			{ x: 2001, y: 1 },
+			{ x: 2002, y: 0 },
+			{ x: 2003, y: 1 },
+			{ x: 2004, y: 1 },
+			{ x: 2005, y: 1 },
+			{ x: 2006, y: 3 },
+			{ x: 2007, y: 1 },
+			{ x: 2008, y: 1 },
+			{ x: 2009, y: 5 },
+			{ x: 2010, y: 0 },
+			{ x: 2011, y: 2 },
+			{ x: 2012, y: 1 },
+			{ x: 2013, y: 1 },
+			{ x: 2014, y: 2 },
+			{ x: 2015, y: 5 },
+			{ x: 2016, y: 3 },
+			{ x: 2017, y: 2 },
+			{ x: 2018, y: 6 },
+			{ x: 2019, y: 1 },
+			{ x: 2020, y: 0 },
+			{ x: 2021, y: 0 },
+			{ x: 2022, y: 3 },
+			{ x: 2023, y: 1 },
+			{ x: 2024, y: 9 },
+			{ x: 2025, y: 10 },
+			{ x: 2026, y: 7 }
+		]
+	}],
+	colors: ['#35eb93']
+}).render();
+</script>
 
 ## Missing data
 

--- a/build/js/charts.js
+++ b/build/js/charts.js
@@ -180,6 +180,7 @@ const data = {
 		lastFmScrobbles: 8153,
 		geocachesFound: 0,
 		gigsAndShows: 2,
+		escapeRooms: 1,
 	},
 	2018: {
 		postsPersonal: 10,
@@ -270,6 +271,7 @@ const data = {
 		lastFmScrobbles: 15158,
 		geocachesFound: 96,
 		gigsAndShows:  1,
+		escapeRooms: 2,
 	},
 	2024: {
 		postsPersonal: 17,
@@ -285,6 +287,7 @@ const data = {
 		lastFmScrobbles: 14942,
 		geocachesFound: 201,
 		gigsAndShows:  9,
+		escapeRooms: 2,
 	},
 	2025: {
 		postsPersonal: 21,
@@ -300,6 +303,11 @@ const data = {
 		lastFmScrobbles: 18155,
 		geocachesFound: 2,
 		gigsAndShows: 10,
+		escapeRooms: 2,
+	},
+	2026: {
+		gigsAndShows: 7,
+		escapeRooms: 3,
 	}
 };
 


### PR DESCRIPTION
Each page now shows an area chart at the top (years on x-axis, count on
y-axis) matching the blog posts graph style from the stats page — same
gradient fill, smooth curve, and brand green (#35eb93).

Also adds escapeRooms data to charts.js (2017–2026) and a 2026 entry for
gigsAndShows, keeping all yearly stats in one place.

https://claude.ai/code/session_01BWQoVLUbmzgvV8z25VbSeN